### PR TITLE
Hardcode patterns directory.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -43,7 +43,7 @@ var Patterns = function() {
         // PostCompile
         pattern.header = _stylize.postCompile(pattern);
 
-        var dest = path.join(_stylize.path, _stylize.config().destination, pattern.parents.join('/'));
+        var dest = path.join(_stylize.path, _stylize.config().destination, 'patterns', pattern.parents.join('/'));
         _stylize.build(dest, pattern.fileName, pattern.header + pattern.compiled + pattern.footer);
         if (key === patternsLength) {
           cb();


### PR DESCRIPTION
Keep the pattern iframes and front-end routes from clobbering one another.
